### PR TITLE
Fix: prevent call of selectCountry() on undefined defaultCountry

### DIFF
--- a/src/js/countrySelect.js
+++ b/src/js/countrySelect.js
@@ -229,7 +229,9 @@
 			if (this.options.initialCountry === "auto") {
 				this._loadAutoCountry();
 			} else {
-				this.selectCountry(this.defaultCountry);
+				if (this.defaultCountry) {
+					this.selectCountry(this.defaultCountry);
+				}
 				this.autoCountryDeferred.resolve();
 			}
 		},


### PR DESCRIPTION
Hi,

First, thank you for your great plugin!

We encounter the case that country-select-js would fail to initialise from the country _value_ (e.g: "France"), with the error: `TypeError: Cannot read property \'toLowerCase\' of undefined`.

This commit fixes the error.

Regards