### PR TITLE
fix(build): fix bower.json to inject css correctly with wiredep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,10 @@
 {
 	"name": "country-select-js",
-	"version": "1.0.9",
+	"version": "2.0.1",
 	"description": "A jQuery plugin for selecting a country",
 	"main": [
-		"build/js/countrySelect.js"
+		"build/js/countrySelect.js",
+		"build/css/countrySelect.css"
 	],
 	"dependencies": {
 		"jquery": ">=1.9.1"


### PR DESCRIPTION
We're using [wiredep](https://github.com/taptapship/wiredep) to inject bower components' js and css files. This fix makes using country-select-js with gulp and bower easier.