### PR TITLE
Change gulp to use run-sequence

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,9 +6,10 @@ var cleanCSS = require('gulp-clean-css');
 var minifyJS = require('gulp-minify');
 var rename = require('gulp-rename');
 var webserver = require('gulp-webserver');
+var runSequence = require('run-sequence');
 
 gulp.task('scss', function () {
-	gulp.src('./src/scss/countrySelect.scss')
+	return gulp.src('./src/scss/countrySelect.scss')
 		.pipe(sass({ errLogToConsole: true  }))
 		.pipe(prefix())
 		.pipe(cleanCSS({compatibility: 'ie8', format: {
@@ -30,7 +31,7 @@ gulp.task('scss', function () {
 });
 
 gulp.task('js', function () {
-	gulp.src('./src/js/countrySelect.js')
+	return gulp.src('./src/js/countrySelect.js')
 		.pipe(gulp.dest('./build/js'))
 		.pipe(notify("javascript updated"));
 });
@@ -38,7 +39,7 @@ gulp.task('js', function () {
 gulp.task('handle-sources', ['scss', 'js']);
 
 gulp.task('minify-scss', function () {
-	gulp.src('./build/css/countrySelect.css')
+	return gulp.src('./build/css/countrySelect.css')
 		.pipe(cleanCSS({level: 2, inline: ['all']}))
 		.pipe(rename({extname: '.min.css'}))
 		.pipe(gulp.dest('./build/css'))
@@ -46,7 +47,7 @@ gulp.task('minify-scss', function () {
 });
 
 gulp.task('minify-js', function () {
-	gulp.src('./build/js/countrySelect.js')
+	return gulp.src('./build/js/countrySelect.js')
 		.pipe(minifyJS({ext:{min:'.min.js'}}))
 		.pipe(gulp.dest('./build/js'))
 		.pipe(notify("javascript minified"));
@@ -66,4 +67,6 @@ gulp.task('webserver', function() {
 });
 
 gulp.task('default', ['handle-sources', 'webserver']);
-gulp.task('build', ['handle-sources', 'minify-sources']);
+gulp.task('build', function() {
+	runSequence('handle-sources', 'minify-sources');
+});

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"gulp-notify": "^3.0.0",
 		"gulp-rename": "^1.2.2",
 		"gulp-sass": "^3.1.0",
-		"gulp-webserver": "^0.9.1"
+		"gulp-webserver": "^0.9.1",
+		"run-sequence": "^2.2.1"
 	}
 }


### PR DESCRIPTION
Related to issue #50 , it happens because running gulp build might result in task ['js'] not run successfully. 
This problem is likely due to the minify-js was run asynchronously and it requires the original file in build folder. Therefore, it prevents the ['js'] task from overwriting with new file from src folder. 

I added package run-sequence to make sure that ['handle-sources'] is run before ['minify-sources']