### PR TITLE
Fix `excludeCountries` option documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Display only the countries you specify. Takes an array of country codes.
 
 **excludeCountries**  
 Type: `Array` Default: `undefined`  
-Display only the countries you specify. Takes an array of country codes.
+Display only the countries not specified. Takes an array of country codes.
 
 **preferredCountries**  
 Type: `Array` Default: `["us", "gb"]`  


### PR DESCRIPTION
It seems `excludeCountries` is for exclusion, meaning the specified countries will not be listed. (Opposite of `onlyCountries`)