### PR TITLE
Add placeholder for country-select-js

### DIFF
--- a/src/js/countrySelect.js
+++ b/src/js/countrySelect.js
@@ -236,9 +236,9 @@
 						defaultCountry = this.preferredCountries.length ? this.preferredCountries[0] : this.countries[0];
 					}
 				} else if (this.options.defaultCountry === '' || typeof this.option.defaultCountry === 'null') {
-                    defaultCountry = this._getCountryData('', true);
+                   				 defaultCountry = this._getCountryData('', true);
 				} else {
-                    defaultCountry = this.preferredCountries.length ? this.preferredCountries[0] : this.countries[0];
+                    				defaultCountry = this.preferredCountries.length ? this.preferredCountries[0] : this.countries[0];
                 }
 				this.defaultCountry = defaultCountry.iso2;
 			}


### PR DESCRIPTION
Added a placeholder for the plugin

in defaultCountry option can be passed in an empty string

it also prevents the plugin throwing errors if the user types in a country that doesn't exist in the plugin
the associated countryCodeInput's will also be set to null

please check if i have overlooked something